### PR TITLE
Add an argument to the workgroup-size-query kernel

### DIFF
--- a/scallion/Program.cs
+++ b/scallion/Program.cs
@@ -88,7 +88,7 @@ namespace scallion
             ulong preferredWorkGroupSize;
             {
                 CLContext context = new CLContext(deviceId);
-                IntPtr program = context.CreateAndCompileProgram(@"__kernel void get_size() { }");
+                IntPtr program = context.CreateAndCompileProgram(@"__kernel void get_size(__global float2 *in) { }");
                 CLKernel kernel = context.CreateKernel(program, "get_size");
                 preferredWorkGroupSize = kernel.KernelPreferredWorkGroupSizeMultiple;
                 kernel.Dispose();


### PR DESCRIPTION
On OSX, the OpenCL compiler doesn't like a kernel that takes no
arguments. This causes an exception to be raised, and eventually
crashes the application. By adding an argument, we allow the kernel to
be compiled

This fixes #7
