### PR TITLE
Fixed "delicions" typo in readme/message output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Generate a hash
 
 
     $ mono scallion/bin/Debug/scallion.exe -d 0 prefix
-    Cooking up some delicions scallions...
+    Cooking up some delicious scallions...
     Using kernel optimized from file kernel.cl (Optimized4)
     Using work group size 128
     Compiling kernel... done.

--- a/scallion/CLRuntime.cs
+++ b/scallion/CLRuntime.cs
@@ -229,7 +229,7 @@ namespace scallion
 			int numThreadsCreateWork = (int)parms.CpuThreads;
 			KernelType kernelt = parms.KernelType;
 
-			Console.WriteLine("Cooking up some delicions scallions...");
+			Console.WriteLine("Cooking up some delicious scallions...");
 			this.workSize = (uint)workSize;
 			profiler = new Profiler();
 			#region init


### PR DESCRIPTION
"delicions scallions" appears to be a typo. Uh, I'm not sure what else to say.