### PR TITLE
Avoid ToolConfig TimeSpan Overflow

### DIFF
--- a/scallion/GpgToolConfig.cs
+++ b/scallion/GpgToolConfig.cs
@@ -11,12 +11,11 @@ namespace scallion
 
 		public GpgToolConfig(string pattern) : base(pattern) { }
 
-		public override TimeSpan PredictRuntime(long hashRate)
+		protected override double PredictRuntimeInSeconds(long hashRate)
 		{
 			// 4 = log_2(16) [for hex address]
 			var hashes_per_win = _regex.GenerateAllPatternsForRegex().Select(t=>Math.Pow(2,4*t.Count(q=>q!='.') - 1)).Sum();
-			long runtime_sec = (long)(hashes_per_win / hashRate);
-			return TimeSpan.FromSeconds(runtime_sec);
+			return (long)(hashes_per_win / hashRate);
 		}
 
 		public override bool CheckMatch(RSAWrapper rsa)

--- a/scallion/OnionToolConfig.cs
+++ b/scallion/OnionToolConfig.cs
@@ -9,12 +9,11 @@ namespace scallion
 
         public OnionToolConfig(string pattern) : base(pattern) { }
 
-		public override TimeSpan PredictRuntime(long hashRate)
+		protected override double PredictRuntimeInSeconds(long hashRate)
         {
 			// 5 = log_2(32) [for base 32 onion address]
 			var hashes_per_win = _regex.GenerateAllPatternsForRegex().Select(t=>Math.Pow(2,5*t.Count(q=>q!='.') - 1)).Sum();
-			long runtime_sec = (long)(hashes_per_win / hashRate);
-			return TimeSpan.FromSeconds(runtime_sec);
+			return (long)(hashes_per_win / hashRate);
         }
 
         public override bool CheckMatch(RSAWrapper rsa)

--- a/scallion/ToolConfig.cs
+++ b/scallion/ToolConfig.cs
@@ -97,7 +97,11 @@ namespace scallion
 		public abstract uint MaximumExponent { get; }
 		public abstract byte[] GetPublicKeyData(RSAWrapper rsa, out int exp_index);
         protected abstract RegexPattern CreateRegexPattern(string pattern);
-        public abstract TimeSpan PredictRuntime(long hashRate);
+        public TimeSpan PredictRuntime(long hashRate)
+        {
+            return TimeSpan.FromSeconds(Math.Min(TimeSpan.MaxValue.TotalSeconds * 0.99, PredictRuntimeInSeconds(hashRate)));
+        }
+        protected abstract double PredictRuntimeInSeconds(long hashRate);
         public abstract bool CheckMatch(RSAWrapper rsa);
         protected abstract IList<BitmaskPatternsTuple> GenerateBitmaskPatterns();
 


### PR DESCRIPTION
The PredictRuntime implementations may attempt to generate a TimeSpan
object that exceeds TimeSpan.MaxValue in total length.  I've added a
wrapper to ToolConfig and changed the interface implemented by
OnionToolConfig and GpgToolConfig so that they can not cause this
exception.

The compromise is that when the timespan is unrealistically large the
value will be incorrect, however since this requires a timespan of over
10,000,000 days it is highly unlikely the user will survive long enough
to notice.