### PR TITLE
Add an entry for the hash speed of the i5-5200U

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ AMD Radeon HD6850        | 600 MH/s
 NVIDIA GTS 250           | 128 MH/s
 Intel i7-2620M           | 9.9 MH/s
 NVIDIA GTX 970           | 2350 MH/s
+Intel i5-5200U           | 118 MH/s
 
 MH/s = million hashes per second
 


### PR DESCRIPTION
Add hash speed for the Intel Core i5-5200U CPU @ 2.20GHz measured on Linux with beignet 1.1.1

Just for some more info on newer Broadwell CPUs.