### PR TITLE
show invalid character for an invalid regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ obj
 *.pdb
 *.suo
 *.userprefs
+*.user
 
 # mstest test results
 TestResults

--- a/scallion/Program.cs
+++ b/scallion/Program.cs
@@ -245,6 +245,11 @@ namespace scallion
 						try {
 		                	_runtime.Run(ProgramParameters.Instance);
 						}
+                        catch (ApplicationException e) {
+                            // these are handled and printed out
+                            Console.Error.WriteLine(e.Message);
+                            Environment.Exit(1);
+                        }
 						finally {
 							Shutdown();
 						}

--- a/scallion/RegexPattern.cs
+++ b/scallion/RegexPattern.cs
@@ -53,6 +53,14 @@ namespace scallion
             public SingleRegexPattern(string regex, int outputLength, string validCharacters)
             {
                 _outputLength = outputLength;
+
+                // check for invalid characters in given regex
+                Regex invalidMarkupRegex = new Regex("[^" + validCharacters + @"\^\$\[\]\.\\]");
+                var invalidMatch = invalidMarkupRegex.Match(regex);
+                if (invalidMatch.Success)
+                    throw new ApplicationException(string.Format("Unsupported character in Regex: '{0}'",
+                        invalidMatch.Value));
+
                 //create the regexRegex
                 Regex regexRegex = new Regex(string.Format(@"\[[{0}]*\]|[{0}.]", validCharacters));
 
@@ -73,7 +81,7 @@ namespace scallion
                     .Replace(@"\d", validCharacters.Where(i => int.TryParse(i.ToString(), out trash)).ToDelimitedString(""));
                 //validate regex
                 if (regexRegex.Matches(regex).Cast<Match>().Sum(i => i.Value.Length) != regex.Length)
-                    throw new System.ArgumentException("The passed regex string is not valid!");
+                    throw new ApplicationException("The passed regex string is not valid!");
                 //_regex = new Regex(regex);
                 //parse regex
                 _parsedRegex =


### PR DESCRIPTION
If a string does not contain a valid regex character, the problematic character is shown. Unnecessary stack trace is skipped for Regex problems.
