### PR TITLE
Added Nvidia 1070

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ NVIDIA GTX 970           | 2350 MH/s
 Intel i5-5200U           | 118 MH/s
 NVIDIA GTS 450           | 144 MH/s
 NVIDIA GTX 980           | 3260 MH/s
+NVIDIA GTX 1070          | 4140 MH/s
 GeForce GT 520           | 38.7 MH/s
 AMD A8-7600 APU          | 120 MH/s
 AMD Radeon RX 470        | 957 MH/s


### PR DESCRIPTION
GPU load wouldn’t go past 92%. But this is the highest number for a 40
minute run.
