### PR TITLE
Fix for python shebang and early thread exiting

### DIFF
--- a/gpgtest.py
+++ b/gpgtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 import struct
 import hashlib
 import base64

--- a/scallion/CLRuntime.cs
+++ b/scallion/CLRuntime.cs
@@ -147,7 +147,6 @@ namespace scallion
 					if(exp_index != parms.ExponentIndex) {
 						Console.WriteLine("Exponent index doesn't match - skipping key");
 						skip_flag = true;
-						break;
 					}
 					/*if(i != 4) { // exponent length assumed to be 4 in the kernel
 						Console.WriteLine("Exponent length doesn't match - skipping key");


### PR DESCRIPTION
I haven't used scallion in a long time, but back when I did I made these changes and I thought I should submit them now. The shebang fix is pretty self-explanatory. The other fix is for when the exponent index doesn't match. I'm not sure if I ever encountered this edge case or if I just noticed the issue in the code. It's clearly meant to just skip over the key in that case, but the break statement actually breaks out of the main loop, ending that thread prematurely.